### PR TITLE
fix(shell): run as noninteractive to prevent getting hung

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ export class PowerShell {
 
         log.info('[>] init process');
 
-        const args = ['-NoLogo', '-NoExit', '-Command', '-'];
+        const args = [ '-NonInteractive', '-NoLogo', '-NoExit', '-Command', '-'];
 
         this.powershell = spawn(this.exe_path, args, { stdio: 'pipe' });
 


### PR DESCRIPTION
If the shell is asked to run something like `Get-Credential` then it will become stuck as it will raise a prompt which cannot be interacted with (assuming this is running server side). By adding `-NonInteractive` it will instead return an error if a prompt would otherwise occur. 

Microsoft defines it as ["Does not present an interactive prompt to the user." ](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1#-noninteractive)